### PR TITLE
typo in popup text (really show lat/lon)

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
                     //set up a standalone popup (use a popup as a layer)
                     L.popup()
                         .setLatLng(point)
-                        .setContent("You clicked the point at longitude:" + point.lng + ', latitude:' + point.lng)
+                        .setContent("You clicked the point at longitude:" + point.lng + ', latitude:' + point.lat)
                         .openOn(map);
 
                     console.log(point);


### PR DESCRIPTION
The popup showed the longitude two times. 