### PR TITLE
ES6 syntax and undefined variable error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": ["/src"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "browserify --external leaflet -t brfs src/js/index.js -o glify.js"
+    "build": "browserify --external leaflet -t brfs src/js/index.js -t [ babelify --presets [ @babel/preset-env ] ] -o glify.js"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,10 @@
     "rbush": "^2.0.2"
   },
   "devDependencies": {
-    "browserify": "^16.2.2",
-    "brfs": "^2.0.1"
+    "@babel/core": "^7.3.4",
+    "@babel/preset-env": "^7.3.4",
+    "babelify": "^10.0.0",
+    "brfs": "^2.0.1",
+    "browserify": "^16.2.2"
   }
 }

--- a/src/js/canvasoverlay.js
+++ b/src/js/canvasoverlay.js
@@ -135,7 +135,7 @@ var CanvasOverlay = L.Layer.extend({
   }
 });
 
-canvasOverlay = function (userDrawFunc, options) {
+var canvasOverlay = function (userDrawFunc, options) {
   return new CanvasOverlay(userDrawFunc, options);
 };
 


### PR DESCRIPTION
Using the library in the **IE11** results in errors that are caused by IE's inability to understand some of the **ES6 syntax**. This pull request uses the `babelify` to transpile the code into the ES5 syntax and fixes minor error with variable definition.