### PR TITLE
adding ability to read GeoJSON points in addition to flat points arrays

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -149,8 +149,8 @@ var glify = {
     return Math.sqrt(dx * dx + dy * dy);
   },
   locationDistance: function (location1, location2, map) {
-    var point1 = map.latLngToLayerPoint(location1),
-        point2 = map.latLngToLayerPoint(location2),
+    var point1 = map.latLngToLayerPoint(location1.hasOwnProperty('geometry') ? location1.geometry.coordinates : location1),
+        point2 = map.latLngToLayerPoint(location2.hasOwnProperty('geometry') ? location2.geometry.coordinates : location2),
 
         dx = point1.x - point2.x,
         dy = point1.y - point2.y;


### PR DESCRIPTION
This is a work in progress; i have it working but need to debug the lookup function for click handling. Looking to the `lines.js` file for a reference... any tips appreciated, thanks!

Basically, I have a huge amount of data in the following GeoJSON format, rather than a flat nested array of `[lat, lon]` tuples:

```json
{
  "type": "FeatureCollection",
  "crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:OGC:1.3:CRS84"}},
  "features":[
    {"geometry":{"coordinates":[-71.4178125,41.81443759],"type":"Point"},"properties":{"name":"WEISS & GEISLER, INC.","sic_name":"Jewelry & Other Miscellaneous Manufacturing","city":"Providence","year":1953,"open":1953,"sic_color":"#008000","street":"409 Pine St","close":1953,"employees":"0-49"},"type":"Feature"},
    {"geometry":{"coordinates":[-71.41780474,41.81480583],"type":"Point"},"properties":{"name":"WEISS & GEISLER, INC.","sic_name":"Jewelry & Other Miscellaneous Manufacturing","city":"Providence","year":1959,"open":1959,"sic_color":"#008000","street":"147 Summer Street","close":1959,"employees":"0-49"},"type":"Feature"}
  ],
}
```

I found `Leaflet.glify` wasn't expecting that, so I made some modifications to allow for this format of GeoJSON, which also allow the properties of each point to be used in the popup, which wasn't previously possible for point data.  

**Update** - ready for review!