### PR TITLE
Fix the distance calculation for showing lines' popup

### DIFF
--- a/src/js/lines.js
+++ b/src/js/lines.js
@@ -432,10 +432,10 @@ Lines.tryClick = function(e, map) {
     if (!settings.click) return;
 
     settings.data.features.map(feature => {
-      for (var i = 1; i < feature.geometry.coordinates.length; i++) {
+      for (var i = 0; i < feature.geometry.coordinates.length; i++) {
         var distance = pDistance(e.latlng.lng, e.latlng.lat,
-          feature.geometry.coordinates[i - 1][0], feature.geometry.coordinates[i - 1][1],
-          feature.geometry.coordinates[i][0], feature.geometry.coordinates[i][1]);
+          feature.geometry.coordinates[i][0][0], feature.geometry.coordinates[i][0][1],
+          feature.geometry.coordinates[i][1][0], feature.geometry.coordinates[i][1][1]);
         if (distance < record) {
           record = distance;
           foundFeature = feature;


### PR DESCRIPTION
The geojson "MultiLineString" feature may have several lines, and every line has two points. Based on that, i did a small change to use the two points for every line when calculating distance from the click. Thanks a lot for the project. It's really nice!