### PR TITLE
fix #42 import Multipart-Geometry

### DIFF
--- a/src/lines.ts
+++ b/src/lines.ts
@@ -169,7 +169,7 @@ export class Lines extends Base<ILinesSettings> {
       }
 
       //coorinates Array Structure depends on whether feature is multipart or not.
-      //Multi: [ [],[],[]... ], Single: []
+      //Multi: [ [[],[],[]...], [[],[],[]...], [[],[],[]...]... ], Single: [ [[],[],[]...] ]
       //Wrap Single Array to treat two types with same method
       coordinates = (feature.geometry || feature).coordinates;
       if (feature.geometry.type !== 'MultiLineString') {

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -149,6 +149,7 @@ export class Lines extends Base<ILinesSettings> {
       , colorFn: (i: number, feature: any) => IColor
       , chosenColor
       , featureIndex = 0
+      , coordinates
       ;
 
     if (!color) {
@@ -167,14 +168,24 @@ export class Lines extends Base<ILinesSettings> {
         chosenColor = color as IColor;
       }
 
-      const featureVertices = new LineFeatureVertices({
-        project: map.project.bind(map),
-        latitudeKey,
-        longitudeKey,
-        color: chosenColor,
-      });
-      featureVertices.fillFromCoordinates(feature.geometry.coordinates);
-      vertices.push(featureVertices);
+      //coorinates Array Structure depends on whether feature is multipart or not.
+      //Multi: [ [],[],[]... ], Single: []
+      //Wrap Single Array to treat two types with same method
+      coordinates = (feature.geometry || feature).coordinates;
+      if (feature.geometry.type !== 'MultiLineString') {
+        coordinates = [coordinates]
+      }
+
+      for (let num in coordinates) {
+        const featureVertices = new LineFeatureVertices({
+          project: map.project.bind(map),
+          latitudeKey,
+          longitudeKey,
+          color: chosenColor,
+        });
+        featureVertices.fillFromCoordinates(coordinates[num]);
+        vertices.push(featureVertices);
+      }
     }
 
     return this;

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -154,7 +154,7 @@ export class Shapes extends Base<IShapeSettings> {
       
       coordinates = (feature.geometry || feature).coordinates;
       //coorinates Array Structure depends on whether feature is multipart or not.
-      //Multi: [ [],[],[]... ], Single: [], [], []...
+      //Multi: [ [],[],[]... ], Single: []
       //Wrap Single Array to treat two types with same method
       if (feature.geometry.type !== 'MultiPolygon') {
         coordinates = [coordinates]

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -133,7 +133,7 @@ export class Shapes extends Base<IShapeSettings> {
         features = data.features;
     }
     featureMax = features.length;
-
+    
     if (!color) {
       throw new Error('color is not properly defined');
     } else if (typeof color === 'function') {
@@ -151,17 +151,25 @@ export class Shapes extends Base<IShapeSettings> {
       } else {
         chosenColor = color as IColor;
       }
-
+      
       coordinates = (feature.geometry || feature).coordinates;
-      flat = earcut.flatten(coordinates);
-      indices = earcut(flat.vertices, flat.holes, flat.dimensions);
-      dim = coordinates[0][0].length;
-      for (let i = 0, iMax = indices.length; i < iMax; i++) {
-        index = indices[i];
-        if (typeof flat.vertices[0] === 'number') {
-          triangles.push(flat.vertices[index * dim + settings.longitudeKey], flat.vertices[index * dim + settings.latitudeKey]);
-        } else {
-          throw new Error('unhandled polygon');
+      //coorinates Array Structure depends on whether feature is multipart or not.
+      //Multi: [ [],[],[]... ], Single: [], [], []...
+      //Wrap Single Array to treat two types with same method
+      if (feature.geometry.type !== 'MultiPolygon') {
+        coordinates = [coordinates]
+      }
+      for (let num in coordinates) {
+        flat = earcut.flatten(coordinates[num]);
+        indices = earcut(flat.vertices, flat.holes, flat.dimensions);
+        dim = coordinates[num][0][0].length;
+        for (let i = 0, iMax = indices.length; i < iMax; i++) {
+          index = indices[i];
+          if (typeof flat.vertices[0] === 'number') {
+            triangles.push(flat.vertices[index * dim + settings.longitudeKey], flat.vertices[index * dim + settings.latitudeKey]);
+          } else {
+            throw new Error('unhandled polygon');
+          }
         }
       }
 

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -153,8 +153,9 @@ export class Shapes extends Base<IShapeSettings> {
       }
       
       coordinates = (feature.geometry || feature).coordinates;
+      console.log(coordinates)
       //coorinates Array Structure depends on whether feature is multipart or not.
-      //Multi: [ [],[],[]... ], Single: []
+      //Multi: [ [[],[],[]...], [[],[],[]...], [[],[],[]...]... ], Single: [ [[],[],[]...] ]
       //Wrap Single Array to treat two types with same method
       if (feature.geometry.type !== 'MultiPolygon') {
         coordinates = [coordinates]

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -153,7 +153,6 @@ export class Shapes extends Base<IShapeSettings> {
       }
       
       coordinates = (feature.geometry || feature).coordinates;
-      console.log(coordinates)
       //coorinates Array Structure depends on whether feature is multipart or not.
       //Multi: [ [[],[],[]...], [[],[],[]...], [[],[],[]...]... ], Single: [ [[],[],[]...] ]
       //Wrap Single Array to treat two types with same method


### PR DESCRIPTION
fix #42 

The issue is caused by GeoJSON structure deference between Multi-Part and not.
The two types of GeoJSON's coordinates is not same structure as following.

multipart: [ [ [lon, lat], [lon, lat], [lon, lat]...], [ [lon, lat], [lon, lat], [lon, lat]...]... ]
singlepart: [ [lon, lat], [lon, lat], [lon, lat]... ] 

So, I've fixed to treat two types in same way by wrapping singlepart coordinates with [].