### PR TITLE
fix: border artefact on mobile

### DIFF
--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -206,7 +206,7 @@ export class Shapes extends BaseGlLayer {
 
       if (border) {
         const lines = [];
-        for (let i = 1, iMax = flat.vertices.length; i < iMax; i = i + 2) {
+        for (let i = 1, iMax = flat.vertices.length - 2; i < iMax; i = i + 2) {
           lines.push(flat.vertices[i], flat.vertices[i - 1]);
           lines.push(flat.vertices[i + 2], flat.vertices[i + 1]);
         }


### PR DESCRIPTION
On mobile, shapes boders have an artefact on mobile caused by `NaN` data.

Expected (and with the PR):
---
![image](https://user-images.githubusercontent.com/2434994/120649106-aea57580-c47c-11eb-8b80-00585ec6e202.png)

Upstream result
---
![image](https://user-images.githubusercontent.com/2434994/120649141-b9f8a100-c47c-11eb-9230-d6e13c96a267.png)
![image](https://user-images.githubusercontent.com/2434994/120649190-c7159000-c47c-11eb-963a-e4df90f1af5b.png)
