### PR TITLE
blend separatly color and alpha

### DIFF
--- a/src/base-gl-layer.test.ts
+++ b/src/base-gl-layer.test.ts
@@ -603,10 +603,12 @@ describe("BaseGlLayer", () => {
     });
     it("calls gl.blendFunc with gl.SRC_ALPHA and gl.ONE_MINUS_SRC_ALPHA", () => {
       const layer = getGlLayer().setupVertexShader().setupFragmentShader();
-      jest.spyOn(layer.gl, "blendFunc");
+      jest.spyOn(layer.gl, "blendFuncSeparate");
       layer.setupProgram();
-      expect(layer.gl.blendFunc).toHaveBeenCalledWith(
+      expect(layer.gl.blendFuncSeparate).toHaveBeenCalledWith(
         layer.gl.SRC_ALPHA,
+        layer.gl.ONE_MINUS_SRC_ALPHA,
+        layer.gl.ONE,
         layer.gl.ONE_MINUS_SRC_ALPHA
       );
     });

--- a/src/base-gl-layer.ts
+++ b/src/base-gl-layer.ts
@@ -286,7 +286,10 @@ export abstract class BaseGlLayer<
     gl.attachShader(program, fragmentShader);
     gl.linkProgram(program);
     gl.useProgram(program);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.blendFuncSeparate(
+      gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA,
+      gl.ONE, gl.ONE_MINUS_SRC_ALPHA
+    );
     gl.enable(gl.BLEND);
 
     this.program = program;


### PR DESCRIPTION
~This PR exposes [`premultipliedAlpha`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) with a default value `false`.~

~From my understanding, with current code, alpha is apply twice on some browser, making color artifact when the background (or any layer under the canvas) is bright.~
Also the result differs from standard leafet colors (svg/canvas) on all browsers I tested.

Looking how to fix the color issue I tried some combinations of `blendFunc`, color/alpha and premultipliedAlpha.

With `gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);` (original)

![image](https://user-images.githubusercontent.com/2434994/120866974-4300fc80-c591-11eb-9408-69566a7f2530.png)

With `gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);`, colors is reproducible as long as the color is multiplied by alpha (so the alpha looks good).

![image](https://user-images.githubusercontent.com/2434994/120866923-24026a80-c591-11eb-8594-d79411ecd8fd.png)

With `gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);`
the result matches usual canvas and svg.

![image](https://user-images.githubusercontent.com/2434994/120867063-704daa80-c591-11eb-9211-b0cc224ae368.png)

Should fix #16 

<details>
```ts
import * as L from 'leaflet';
import { Polygon } from 'leaflet';
import glify from './src/index';

const map = L.map('map')
  .setView([0, 0], 8);

(map.getContainer() as any)._leaflet_map = map;

const alpha = .2;

function square(x: number, y: number, size?: number): Polygon {
  size = size ? size : 1;
  return L.rectangle([[x-size/2,y-size/2],[x+size/2,y+size/2]]);
}

function info(x: number, y: number, text: string) {
  L.marker([.4+x,-.4+y], {
    icon: L.divIcon({html: '<pre>' + text + '</pre>'}),
  }).addTo(map);
}

function template(x: number, y: number, text: string, cb: (p:Polygon[]) => any) {
  const polys = [];
  for (var s = 1; s > 0; s -= .1) {
    polys.push(square(x+.5-s/4, y+.5-s/4, s/2));
    polys.push(square(x-.5+s/4, y+.5-s/4, s/2));
    polys.push(square(x-.5+s/4, y-.5+s/4, s/2));
    polys.push(square(x+.5-s/4, y-.5+s/4, s/2));
  }
  cb(polys);
  info(x, y, text);
}

template(0, 0, `No-GL\ncolor:\n  (1,.0625,0,${alpha})`, (polys) =>
  polys.forEach((p: Polygon) => p.setStyle({weight: 0, fillColor: '#f10', fillOpacity: alpha}).addTo(map))
);

template(1, 0, `GL\npremultipliedAlpha:\n  false\ncolor:\n  (1,.0625,0,${alpha})`, (polys) =>
  glify.shapes({
    map: map,
    data: {
      type: "FeatureCollection",
      features: polys.map((p) => (p as Polygon).toGeoJSON()),
    },
    color: {r:1,g:.0625,b:0,a:alpha},
    premultipliedAlpha: false,
  })
);
template(-1, 0, `GL\npremultipliedAlpha:\n  true\ncolor:\n  (1,.0625,0,${alpha})`, (polys) =>
  glify.shapes({
    map: map,
    data: {
      type: "FeatureCollection",
      features: polys.map((p) => (p as Polygon).toGeoJSON()),
    },
    color: {r:1,g:.0625,b:0,a:alpha},
    premultipliedAlpha: true,
  })
);
template(0, -1, `GL\npremultipliedAlpha:\n  false\ncolor:\n  (${alpha},${alpha*.0625},0,${alpha})`, (polys) =>
  glify.shapes({
    map: map,
    data: {
      type: "FeatureCollection",
      features: polys.map((p) => (p as Polygon).toGeoJSON()),
    },
    color: {r:alpha,g:.0625*alpha,b:0,a:alpha},
    premultipliedAlpha: false,
  })
);
template(0, 1, `GL\npremultipliedAlpha:\n  true\ncolor:\n  (${alpha},${alpha*.0625},0,${alpha})`, (polys) =>
  glify.shapes({
    map: map,
    data: {
      type: "FeatureCollection",
      features: polys.map((p) => (p as Polygon).toGeoJSON()),
    },
    color: {r:alpha,g:.0625*alpha,b:0,a:alpha},
    premultipliedAlpha: true,
  })
);
```
</details>