### PR TITLE
Fix hole to non-hole vertex border draw bug

### DIFF
--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -235,9 +235,16 @@ export class Shapes extends BaseGlLayer {
 
       if (border) {
         const lines = [];
+        let holeIndex = 0;
+        let skipLineIndices = flat.holes.map(i => ((i+1)*2)-1);
         for (let i = 1, iMax = flat.vertices.length - 2; i < iMax; i = i + 2) {
-          lines.push(flat.vertices[i], flat.vertices[i - 1]);
-          lines.push(flat.vertices[i + 2], flat.vertices[i + 1]);
+          // Skip draw between hole and non-hole vertext
+          if(flat.holes.length == 0 || i + 2 != skipLineIndices[holeIndex]) {
+            lines.push(flat.vertices[i], flat.vertices[i - 1]);
+            lines.push(flat.vertices[i + 2], flat.vertices[i + 1]);
+          } else {
+            holeIndex++;
+          }
         }
 
         for (let i = 0, iMax = lines.length; i < iMax; i) {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -236,10 +236,9 @@ export class Shapes extends BaseGlLayer {
       if (border) {
         const lines = [];
         let holeIndex = 0;
-        let skipLineIndices = flat.holes.map(i => ((i+1)*2)-1);
         for (let i = 1, iMax = flat.vertices.length - 2; i < iMax; i = i + 2) {
           // Skip draw between hole and non-hole vertext
-          if(flat.holes.length == 0 || i + 2 != skipLineIndices[holeIndex]) {
+          if(((i + 1) / 2) !== flat.holes[holeIndex]) {
             lines.push(flat.vertices[i], flat.vertices[i - 1]);
             lines.push(flat.vertices[i + 2], flat.vertices[i + 1]);
           } else {


### PR DESCRIPTION
### Discussion
Polygons with holes draw a border between the last and first vertices of consequent holes. This is because lines are getting drawn between every vertex in a polygon. This makes polygons with many holes have many border lines connecting all the holes. This addition uses the earcut `flat.holes` array to skip drawing a border between the last outer polygon vertex and the first hole vertex, as well as the last vertex of any hole and the first vertex of the next hole.
### Example
The simple polygon with a hole below can be used an as example. Without this PR, there is a line between one of the corners of the polygon to one of the corners of the hole. With the PR that line is not drawn.
```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              6.767578125,
              46.619261036171515
            ],
            [
              13.447265624999998,
              46.619261036171515
            ],
            [
              13.447265624999998,
              51.12421275782688
            ],
            [
              6.767578125,
              51.12421275782688
            ],
            [
              6.767578125,
              46.619261036171515
            ]
          ],
          [[
              7.998046875,
              47.45780853075031
            ],
            [
              12.392578125,
              47.45780853075031
            ],
            [
              12.392578125,
              50.14874640066278
            ],
            [
              7.998046875,
              50.14874640066278
            ],
            [
              7.998046875,
              47.45780853075031
            ]]
        ]
      }
    }
  ]
}
```