### PR TITLE
Remove whole Instances

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,11 +15,12 @@ yarn.lock
 # code coverage
 __coverage__
 
-tests*.*
+src/tests/**
+test*.*
 
-tests/unit/coverage/**
-tests/unit/*.js
-tests/e2e/*.js
+test/unit/coverage/**
+test/unit/*.js
+test/e2e/*.js
 **.min.js
 dist/
 __coverage__/

--- a/.eslintignore
+++ b/.eslintignore
@@ -15,11 +15,11 @@ yarn.lock
 # code coverage
 __coverage__
 
-test*.*
+tests*.*
 
-test/unit/coverage/**
-test/unit/*.js
-test/e2e/*.js
+tests/unit/coverage/**
+tests/unit/*.js
+tests/e2e/*.js
 **.min.js
 dist/
 __coverage__/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,7 @@
     "no-prototype-builtins": "off",
     "no-restricted-globals": "off",
     "no-underscore-dangle": "off",
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "semi": "off",
     "standard/no-callback-literal": "off"
   }

--- a/jest.config.json
+++ b/jest.config.json
@@ -14,5 +14,6 @@
   "testEnvironment": "jsdom",
   "transform": {
     "^.+\\.glsl": "jest-raw-loader"
-  }
+  },
+  "testMatch": ["**/tests/**/*.test.ts"]
 }

--- a/src/base-gl-layer.ts
+++ b/src/base-gl-layer.ts
@@ -17,7 +17,11 @@ export type EventCallback = (
   feature: any
 ) => boolean | void;
 
-export type SetupHoverCallback = (map: Map, hoverWait?: number, immediate?: false) => void;
+export type SetupHoverCallback = (
+  map: Map,
+  hoverWait?: number,
+  immediate?: false
+) => void;
 
 export interface IBaseGlLayerSettings {
   data: any;
@@ -77,6 +81,7 @@ export abstract class BaseGlLayer<
   static defaults = defaults;
 
   abstract render(): this;
+  abstract removeInstance(this: any): this;
 
   get data(): any {
     if (!this.settings.data) {
@@ -312,6 +317,7 @@ export abstract class BaseGlLayer<
 
   remove(indices?: number | number[]): this {
     if (indices === undefined) {
+      this.removeInstance();
       this.map.removeLayer(this.layer);
       this.active = false;
     } else {

--- a/src/canvas-overlay.ts
+++ b/src/canvas-overlay.ts
@@ -45,6 +45,7 @@ export class CanvasOverlay extends Layer {
   _pane: string;
 
   _frame?: number | null;
+  _leaflet_id?: number;
   options?: LayerOptions;
 
   constructor(userDrawFunc: IUserDrawFunc, pane: string) {

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -16,6 +16,7 @@ import { ICanvasOverlayDrawEvent } from "./canvas-overlay";
 import * as color from "./color";
 import { LineFeatureVertices } from "./line-feature-vertices";
 import { latLngDistance, inBounds } from "./utils";
+import glify from "./index";
 
 export type WeightCallback = (i: number, feature: any) => number;
 
@@ -220,6 +221,16 @@ export class Lines extends BaseGlLayer<ILinesSettings> {
     this.allVertices = allVertices;
     this.allVerticesTyped = new Float32Array(allVertices);
 
+    return this;
+  }
+
+  removeInstance(): this {
+    const index = glify.linesInstances.findIndex(
+      (element) => element.layer._leaflet_id === this.layer._leaflet_id
+    );
+    if (index !== -1) {
+      glify.linesInstances.splice(index, 1);
+    }
     return this;
   }
 

--- a/src/points.ts
+++ b/src/points.ts
@@ -11,6 +11,7 @@ import * as Color from "./color";
 import { LeafletMouseEvent, Map, Point, LatLng } from "leaflet";
 import { IPixel } from "./pixel";
 import { locationDistance, pixelInCircle } from "./utils";
+import glify from "./index";
 
 export interface IPointsSettings extends IBaseGlLayerSettings {
   data: number[][] | FeatureCollection<GeoPoint>;
@@ -284,6 +285,16 @@ export class Points extends BaseGlLayer<IPointsSettings> {
       }
     }
 
+    return this;
+  }
+
+  removeInstance(): this {
+    const index = glify.pointsInstances.findIndex(
+      (element) => element.layer._leaflet_id === this.layer._leaflet_id
+    );
+    if (index !== -1) {
+      glify.pointsInstances.splice(index, 1);
+    }
     return this;
   }
 

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -20,6 +20,7 @@ import * as Color from "./color";
 import { latLonToPixel } from "./utils";
 
 import { notProperlyDefined } from "./errors";
+import glify from "./index";
 
 export interface IShapesSettings extends IBaseGlLayerSettings {
   border?: boolean;
@@ -254,6 +255,16 @@ export class Shapes extends BaseGlLayer {
       }
     }
 
+    return this;
+  }
+
+  removeInstance(): this {
+    const index = glify.shapesInstances.findIndex(
+      (element) => element.layer._leaflet_id === this.layer._leaflet_id
+    );
+    if (index !== -1) {
+      glify.shapesInstances.splice(index, 1);
+    }
     return this;
   }
 

--- a/src/tests/base-gl-layer.test.ts
+++ b/src/tests/base-gl-layer.test.ts
@@ -4,11 +4,11 @@ import {
   defaultPane,
   EventCallback,
   IBaseGlLayerSettings,
-} from "./base-gl-layer";
-import { ICanvasOverlayDrawEvent } from "./canvas-overlay";
+} from "../base-gl-layer";
+import { ICanvasOverlayDrawEvent } from "../canvas-overlay";
 import { LatLng, LatLngBounds, LeafletMouseEvent, Map, Point } from "leaflet";
 
-jest.mock("./canvas-overlay");
+jest.mock("../canvas-overlay");
 
 describe("BaseGlLayer", () => {
   interface ITestLayerSettings extends IBaseGlLayerSettings {}
@@ -18,6 +18,10 @@ describe("BaseGlLayer", () => {
     }
 
     render(): this {
+      return this;
+    }
+
+    removeInstance(): this {
       return this;
     }
   }

--- a/src/tests/canvas-overlay.test.ts
+++ b/src/tests/canvas-overlay.test.ts
@@ -1,4 +1,4 @@
-import { CanvasOverlay } from "./canvas-overlay";
+import { CanvasOverlay } from "../canvas-overlay";
 import {
   Bounds,
   LatLng,

--- a/src/tests/color.test.ts
+++ b/src/tests/color.test.ts
@@ -1,4 +1,4 @@
-import { fromHex, pallet, random } from "./color";
+import { fromHex, pallet, random } from "../color";
 
 describe("color", () => {
   test("fromHex", () => {

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -1,4 +1,4 @@
-import { notProperlyDefined } from "./errors";
+import { notProperlyDefined } from "../errors";
 
 describe("notProperlyDefined", () => {
   it("uses properly defined message", () => {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,13 +1,13 @@
-import { Glify } from "./index";
-import { IPointsSettings, Points } from "./points";
-import { ILinesSettings, Lines } from "./lines";
-import { IShapesSettings, Shapes } from "./shapes";
+import { Glify } from "../index";
+import { IPointsSettings, Points } from "../points";
+import { ILinesSettings, Lines } from "../lines";
+import { IShapesSettings, Shapes } from "../shapes";
 import { LatLng, LeafletMouseEvent, Map, Point } from "leaflet";
 import { FeatureCollection, LineString, MultiPolygon } from "geojson";
 
-jest.mock("./canvas-overlay");
+jest.mock("../canvas-overlay");
 type mouseEventFunction = (e: LeafletMouseEvent) => void;
-jest.mock("./utils", () => {
+jest.mock("../utils", () => {
   return {
     debounce: (fn: mouseEventFunction) => {
       return (e: LeafletMouseEvent) => fn(e);

--- a/src/tests/line-feature-vertices.test.ts
+++ b/src/tests/line-feature-vertices.test.ts
@@ -1,6 +1,6 @@
-import { LineFeatureVertices } from "./line-feature-vertices";
+import { LineFeatureVertices } from "../line-feature-vertices";
 import { LatLng } from "leaflet";
-import { IPixel } from "./pixel";
+import { IPixel } from "../pixel";
 import { Position } from "geojson";
 
 describe("LineFeatureVertices", () => {

--- a/src/tests/lines.test.ts
+++ b/src/tests/lines.test.ts
@@ -1,11 +1,11 @@
 import { LatLng, LatLngBounds, LeafletMouseEvent, Map, Point } from "leaflet";
 import { Feature, FeatureCollection, LineString } from "geojson";
-import { MapMatrix } from "./map-matrix";
-import { ICanvasOverlayDrawEvent } from "./canvas-overlay";
-import { ILinesSettings, Lines, WeightCallback } from "./lines";
+import { MapMatrix } from "../map-matrix";
+import { ICanvasOverlayDrawEvent } from "../canvas-overlay";
+import { ILinesSettings, Lines, WeightCallback } from "../lines";
 
-jest.mock("./canvas-overlay");
-jest.mock("./utils", () => {
+jest.mock("../canvas-overlay");
+jest.mock("../utils", () => {
   return {
     inBounds: () => true,
     latLngDistance: () => 2,

--- a/src/tests/map-matrix.test.ts
+++ b/src/tests/map-matrix.test.ts
@@ -1,4 +1,4 @@
-import { MapMatrix } from "./map-matrix";
+import { MapMatrix } from "../map-matrix";
 
 describe("MapMatrix", () => {
   describe("constructor", () => {

--- a/src/tests/points.test.ts
+++ b/src/tests/points.test.ts
@@ -1,9 +1,9 @@
 import { LatLng, LatLngBounds, Map, Point } from "leaflet";
 import { FeatureCollection, Point as GeoPoint } from "geojson";
-import { IPointVertex, IPointsSettings, Points } from "./points";
-import { ICanvasOverlayDrawEvent } from "./canvas-overlay";
+import { IPointVertex, IPointsSettings, Points } from "../points";
+import { ICanvasOverlayDrawEvent } from "../canvas-overlay";
 
-jest.mock("./canvas-overlay");
+jest.mock("../canvas-overlay");
 
 function getPoints(settings?: Partial<IPointsSettings>): Points {
   const element = document.createElement("div");

--- a/src/tests/shapes.test.ts
+++ b/src/tests/shapes.test.ts
@@ -4,10 +4,10 @@ import geojsonFlatten from "geojson-flatten";
 import PolygonLookup from "polygon-lookup";
 import earcut from "earcut";
 
-import { IShapesSettings, Shapes } from "./shapes";
-import { notProperlyDefined } from "./errors";
+import { IShapesSettings, Shapes } from "../shapes";
+import { notProperlyDefined } from "../errors";
 
-jest.mock("./canvas-overlay");
+jest.mock("../canvas-overlay");
 jest.mock("geojson-flatten", () => {
   const realGeojsonFlatten = jest.requireActual<typeof geojsonFlatten>(
     "geojson-flatten"

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -3,7 +3,7 @@ import {
   latLngDistance,
   pixelInCircle,
   vectorDistance,
-} from "./utils";
+} from "../utils";
 
 describe("utils", () => {
   describe("latLonToPixel", () => {


### PR DESCRIPTION
- Also remove the instance, when removing the whole layer. For this I am using the `_leaflet_id` defined in `CanvasOverlay`. Maybe there is a better way of doing this? 
This should fix #129

- move tests to separate folder `/src/tests`

- Changed `"prettier/prettier": "error",` to `"prettier/prettier": ["error", { "endOfLine": "auto" }]`, otherwise my editor would show this error `Delete "␍"` in every file and for every line.. (..Windows 🤪)