### PR TITLE
update/insert accept array or single feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,28 +149,30 @@ L.glify.lines({
 * `shapes(options)`
 * `lines(options)`
 
-
 ## Building
 
-There are two ways to package this application: Parcel and WebPack.
-
-You can build the parcel version by running ``yarn run build-browser``
-You can build the webpack version by running ``yarn run build-browser-webpack``
+You can build by running `npm run build`
 
 ## Developing
-Use `yarn serve`
+
+Use `npm run serve`
 
 ## Testing
-Use `yarn test`
 
-## Update & Remove Data
-L.glify instances can be updated using the `update(data, index)` method.
-* `data` `{Object}` Lines and Shapes require a single GeoJSON feature. Points require the same data structure as the original object and therefore also accept an array of coordinates.
-* `index` `{number}` An integer indicating the index of the element to be updated.
+Use `npm run test`
+
+## Update & Insert & Remove Data
+
+L.glify instances can be manipulated using the `update(data, index)` or `insert(data, index)` method.
+
+- `data` `{Object}` Lines and Shapes accept either a single GeoJSON feature or an array of GeoJSON features. Points require the same data structure as the original object and therefore also accept an array of coordinates.
+- `index` `{number}` An integer indicating the starting index of the element(s) to be updated/inserted.
 
 An object or some elements of an object are removed using the `remove(index)` method.
-* `index` `{number|Array}` optional - An integer or an array of integers specifying the indices of the elements to be removed.
+
+- `index` `{number|Array}` optional - An integer or an array of integers specifying the indices of the elements to be removed.
   If `index` is not defined, the entire object is removed.
+  
 
 ## Contributors
 

--- a/src/base-gl-layer.ts
+++ b/src/base-gl-layer.ts
@@ -17,7 +17,11 @@ export type EventCallback = (
   feature: any
 ) => boolean | void;
 
-export type SetupHoverCallback = (map: Map, hoverWait?: number, immediate?: false) => void;
+export type SetupHoverCallback = (
+  map: Map,
+  hoverWait?: number,
+  immediate?: false
+) => void;
 
 export interface IBaseGlLayerSettings {
   data: any;
@@ -333,15 +337,28 @@ export abstract class BaseGlLayer<
     return this;
   }
 
-  insert(feature: any, index: number): this {
-    const features = this.settings.data.features || this.settings.data;
-    features.splice(index, 0, feature);
+  insert(features: any | any[], index: number): this {
+    const featuresArray = Array.isArray(features) ? features : [features];
+    const featuresData = this.settings.data.features || this.settings.data;
+
+    for (let i = 0; i < featuresArray.length; i++) {
+      featuresData.splice(index + i, 0, featuresArray[i]);
+    }
+
     return this.render();
   }
 
-  update(feature: any, index: number): this {
-    const features = this.settings.data.features || this.settings.data;
-    features[index] = feature;
+  update(feature: any | any[], index: number): this {
+    const featuresData = this.settings.data.features || this.settings.data;
+
+    if (Array.isArray(feature)) {
+      for (let i = 0; i < feature.length; i++) {
+        featuresData[index + i] = feature[i];
+      }
+    } else {
+      featuresData[index] = feature;
+    }
+
     return this.render();
   }
 


### PR DESCRIPTION
The `update/insert` methods currently just accept a single GeoJson feature.

This PR makes it possible to update/insert an array of features.