### PR TITLE
fix: check _map is assigned to avoid errors on often redraw from scratch

### DIFF
--- a/src/canvas-overlay.ts
+++ b/src/canvas-overlay.ts
@@ -165,29 +165,31 @@ export class CanvasOverlay extends Layer {
 
   _redraw(): void {
     const { _map, canvas } = this;
-    const size = _map.getSize();
-    const bounds = _map.getBounds();
-    const zoomScale =
-      (size.x * 180) / (20037508.34 * (bounds.getEast() - bounds.getWest())); // resolution = 1/zoomScale
-    const zoom = _map.getZoom();
-    const topLeft = new LatLng(bounds.getNorth(), bounds.getWest());
-    const offset = this._unclampedProject(topLeft, 0);
-    if (canvas) {
-      this._userDrawFunc({
-        bounds,
-        canvas,
-        offset,
-        scale: Math.pow(2, zoom),
-        size,
-        zoomScale,
-        zoom,
-      });
-    }
+    if (_map) {
+      const size = _map.getSize();
+      const bounds = _map.getBounds();
+      const zoomScale =
+        (size.x * 180) / (20037508.34 * (bounds.getEast() - bounds.getWest())); // resolution = 1/zoomScale
+      const zoom = _map.getZoom();
+      const topLeft = new LatLng(bounds.getNorth(), bounds.getWest());
+      const offset = this._unclampedProject(topLeft, 0);
+      if (canvas) {
+        this._userDrawFunc({
+          bounds,
+          canvas,
+          offset,
+          scale: Math.pow(2, zoom),
+          size,
+          zoomScale,
+          zoom,
+        });
+      }
 
-    while (this._redrawCallbacks.length > 0) {
-      const callback = this._redrawCallbacks.shift();
-      if (callback) {
-        callback(this);
+      while (this._redrawCallbacks.length > 0) {
+        const callback = this._redrawCallbacks.shift();
+        if (callback) {
+          callback(this);
+        }
       }
     }
 


### PR DESCRIPTION
This commit fixes the issue with attempt to draw points on uninitialized map.

Reproduce on https://wio2.utilmind.com/demo/

1. Go to the page by link above and open browser console to see errors.
2. Wait until map is loaded.
3. Turn on "Weather" layer, which is based on glify.points().
![image](https://github.com/user-attachments/assets/c776e833-aca4-4f40-9dab-3f429a87284d)
4. Drag slider to switch weather frames too fast and too often.
![image](https://github.com/user-attachments/assets/627c65c6-5d2d-46ae-85c5-68e9b9d0aa15)

This fix only inserts validation whether `_map` is not empty to line # 168. (And the rest of changes are just shift due to formatting).