### PR TITLE
feat: contextmenu handler

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -25,6 +25,15 @@ Promise.all([
 
       console.log("clicked on Shape", feature, e);
     },
+    contextMenu: (e, feature): void => {
+      e.originalEvent.preventDefault(); // Prevent the default context menu from showing
+      L.popup()
+        .setLatLng(e.latlng)
+        .setContent(`You right clicked on ${feature.properties.NAZKR_ENG}`)
+        .openOn(map);
+
+      console.log("clicked on Shape", feature, e);
+    },
     hover: (e: LeafletMouseEvent, feature) => {
       console.log("hovered on Shape", feature, e);
     },
@@ -44,6 +53,14 @@ Promise.all([
         .openOn(map);
 
       console.log("clicked on Line", feature, e);
+    },
+    contextMenu: (e: LeafletMouseEvent, feature) => {
+      e.originalEvent.preventDefault(); // Prevent the default context menu from showing
+      //set up a standalone popup (use a popup as a layer)
+      L.popup()
+        .setLatLng(e.latlng)
+        .setContent(`right clicked on Line ${feature.properties.name}`)
+        .openOn(map);
     },
     hover: (e: LeafletMouseEvent, feature) => {
       console.log("hovered on Line", feature, e);
@@ -73,6 +90,16 @@ Promise.all([
 
       console.log("clicked on Point", feature, e);
     },
+    contextMenu: (e: LeafletMouseEvent, feature) => {
+      e.originalEvent.preventDefault(); // Prevent the default context menu from showing
+      //set up a standalone popup (use a popup as a layer)
+      L.popup()
+        .setLatLng(feature)
+        .setContent(
+          `You right clicked the point at longitude:${e.latlng.lng}, latitude:${e.latlng.lat}`
+        )
+        .openOn(map);
+    },
     data: points,
   });
 
@@ -94,6 +121,18 @@ Promise.all([
         .setLatLng(feature)
         .setContent(
           `You clicked the point at longitude:${e.latlng.lng}, latitude:${e.latlng.lat}`
+        )
+        .openOn(map);
+
+      console.log("clicked on Point", feature, e);
+    },
+    contextMenu: (e: LeafletMouseEvent, feature) => {
+      e.originalEvent.preventDefault(); // Prevent the default context menu from showing
+      //set up a standalone popup (use a popup as a layer)
+      L.popup()
+        .setLatLng(feature)
+        .setContent(
+          `You right clicked the point at longitude:${e.latlng.lng}, latitude:${e.latlng.lat}`
         )
         .openOn(map);
 
@@ -126,6 +165,16 @@ Promise.all([
       L.popup()
         .setLatLng(feature.geometry.coordinates)
         .setContent("You clicked on:" + feature.properties.name)
+        .openOn(map);
+
+      console.log("clicked on Point", feature, e);
+    },
+    contextMenu: (e, feature) => {
+      e.originalEvent.preventDefault(); // Prevent the default context menu from showing
+      //set up a standalone popup (use a popup as a layer)
+      L.popup()
+        .setLatLng(feature.geometry.coordinates)
+        .setContent("You right clicked on:" + feature.properties.name)
         .openOn(map);
 
       console.log("clicked on Point", feature, e);
@@ -168,6 +217,15 @@ Promise.all([
       L.popup()
         .setLatLng(e.latlng)
         .setContent(`You clicked on ${feature.properties.name}`)
+        .openOn(map);
+
+      console.log("clicked on Shape", feature, e);
+    },
+    contextMenu: (e, feature) => {
+      e.originalEvent.preventDefault(); // Prevent the default context menu from showing
+      L.popup()
+        .setLatLng(e.latlng)
+        .setContent(`You right clicked on ${feature.properties.name}`)
         .openOn(map);
 
       console.log("clicked on Shape", feature, e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export class Glify {
   longitudeKey = 1;
   latitudeKey = 0;
   clickSetupMaps: Map[] = [];
+  contextMenuSetupMaps: Map[] = [];
   hoverSetupMaps: Map[] = [];
   shader = shader;
 
@@ -63,6 +64,7 @@ export class Glify {
   points(settings: Partial<IPointsSettings>): Points {
     const points = new this.Points({
       setupClick: this.setupClick.bind(this),
+      setupContextMenu: this.setupContextMenu.bind(this),
       setupHover: this.setupHover.bind(this),
       latitudeKey: glify.latitudeKey,
       longitudeKey: glify.longitudeKey,
@@ -81,6 +83,7 @@ export class Glify {
   lines(settings: Partial<ILinesSettings>): Lines {
     const lines = new this.Lines({
       setupClick: this.setupClick.bind(this),
+      setupContextMenu: this.setupContextMenu.bind(this),
       setupHover: this.setupHover.bind(this),
       latitudeKey: this.latitudeKey,
       longitudeKey: this.longitudeKey,
@@ -99,6 +102,7 @@ export class Glify {
   shapes(settings: Partial<IShapesSettings>): Shapes {
     const shapes = new this.Shapes({
       setupClick: this.setupClick.bind(this),
+      setupContextMenu: this.setupContextMenu.bind(this),
       setupHover: this.setupHover.bind(this),
       latitudeKey: this.latitudeKey,
       longitudeKey: this.longitudeKey,
@@ -126,6 +130,23 @@ export class Glify {
       if (hit !== undefined) return hit;
 
       hit = this.Shapes.tryClick(e, map, this.shapesInstances);
+      if (hit !== undefined) return hit;
+    });
+  }
+
+  setupContextMenu(map: Map): void {
+    if (this.contextMenuSetupMaps.includes(map)) return;
+    this.clickSetupMaps.push(map);
+    map.on("contextmenu", (e: LeafletMouseEvent) => {
+      e.originalEvent.preventDefault(); // Prevent the default context menu from showing
+      let hit;
+      hit = this.Points.tryContextMenu(e, map, this.pointsInstances);
+      if (hit !== undefined) return hit;
+
+      hit = this.Lines.tryContextMenu(e, map, this.linesInstances);
+      if (hit !== undefined) return hit;
+
+      hit = this.Shapes.tryContextMenu(e, map, this.shapesInstances);
       if (hit !== undefined) return hit;
     });
   }

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -411,6 +411,89 @@ export class Lines extends BaseGlLayer<ILinesSettings> {
     }
   }
 
+  // attempts to click the top-most Lines instance
+  static tryContextMenu(
+    e: LeafletMouseEvent,
+    map: Map,
+    instances: Lines[]
+  ): boolean | undefined {
+    let foundFeature: Feature<LineString | MultiLineString> | null = null;
+    let foundLines: Lines | null = null;
+
+    instances.forEach((instance: Lines): void => {
+      const { latitudeKey, longitudeKey, sensitivity, weight, scale, active } =
+        instance;
+      if (!active) return;
+      if (instance.map !== map) return;
+      function checkContextMenu(
+        coordinate: Position,
+        prevCoordinate: Position,
+        feature: Feature<LineString | MultiLineString>,
+        chosenWeight: number
+      ): void {
+        const distance = latLngDistance(
+          e.latlng.lng,
+          e.latlng.lat,
+          prevCoordinate[longitudeKey],
+          prevCoordinate[latitudeKey],
+          coordinate[longitudeKey],
+          coordinate[latitudeKey]
+        );
+        if (distance <= sensitivity + chosenWeight / scale) {
+          foundFeature = feature;
+          foundLines = instance;
+        }
+      }
+      instance.data.features.forEach(
+        (feature: Feature<LineString | MultiLineString>, i: number): void => {
+          const chosenWeight =
+            typeof weight === "function" ? weight(i, feature) : weight;
+          const { coordinates, type } = feature.geometry;
+          if (type === "LineString") {
+            for (let i = 1; i < coordinates.length; i++) {
+              checkContextMenu(
+                coordinates[i] as Position,
+                coordinates[i - 1] as Position,
+                feature,
+                chosenWeight
+              );
+            }
+          } else if (type === "MultiLineString") {
+            // TODO: Unit test
+            for (let i = 0; i < coordinates.length; i++) {
+              const coordinate = coordinates[i];
+              for (let j = 0; j < coordinate.length; j++) {
+                if (j === 0 && i > 0) {
+                  const prevCoordinates = coordinates[i - 1];
+                  const lastPositions =
+                    prevCoordinates[prevCoordinates.length - 1];
+                  checkContextMenu(
+                    lastPositions as Position,
+                    coordinates[i][j] as Position,
+                    feature,
+                    chosenWeight
+                  );
+                } else if (j > 0) {
+                  checkContextMenu(
+                    coordinates[i][j] as Position,
+                    coordinates[i][j - 1] as Position,
+                    feature,
+                    chosenWeight
+                  );
+                }
+              }
+            }
+          }
+        }
+      );
+    });
+
+    if (foundLines && foundFeature) {
+      const result = (foundLines as Lines).contextMenu(e, foundFeature);
+      return result !== undefined ? result : undefined;
+    }
+  }
+
   hoveringFeatures: Array<Feature<LineString | MultiLineString>> = [];
   // hovers all touching Lines instances
   static tryHover(

--- a/src/points.ts
+++ b/src/points.ts
@@ -156,9 +156,8 @@ export class Points extends BaseGlLayer<IPointsSettings> {
       mapCenterPixels,
     } = this;
     const { eachVertex } = settings;
-    let colorFn:
-      | ((i: number, latLng: LatLng | any) => Color.IColor)
-      | null = null;
+    let colorFn: ((i: number, latLng: LatLng | any) => Color.IColor) | null =
+      null;
     let chosenColor: Color.IColor;
     let chosenSize: number;
     let sizeFn;
@@ -312,7 +311,15 @@ export class Points extends BaseGlLayer<IPointsSettings> {
   drawOnCanvas(e: ICanvasOverlayDrawEvent): this {
     if (!this.gl) return this;
 
-    const { gl, canvas, mapMatrix, matrix, map, allLatLngLookup, mapCenterPixels } = this;
+    const {
+      gl,
+      canvas,
+      mapMatrix,
+      matrix,
+      map,
+      allLatLngLookup,
+      mapCenterPixels,
+    } = this;
     const { offset } = e;
     const zoom = map.getZoom();
     const scale = Math.pow(2, zoom);
@@ -320,7 +327,10 @@ export class Points extends BaseGlLayer<IPointsSettings> {
     mapMatrix
       .setSize(canvas.width, canvas.height)
       .scaleTo(scale)
-      .translateTo(-offset.x + mapCenterPixels.x, -offset.y + mapCenterPixels.y);
+      .translateTo(
+        -offset.x + mapCenterPixels.x,
+        -offset.y + mapCenterPixels.y
+      );
 
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.viewport(0, 0, canvas.width, canvas.height);
@@ -419,6 +429,50 @@ export class Points extends BaseGlLayer<IPointsSettings> {
       pixelInCircle(xy, e.layerPoint, found.chosenSize * (sensitivity ?? 1))
     ) {
       result = instance.click(e, found.feature || found.latLng);
+      return result !== undefined ? result : true;
+    }
+  }
+
+  // attempts to click the top-most Points instance
+  static tryContextMenu(
+    e: LeafletMouseEvent,
+    map: Map,
+    instances: Points[]
+  ): boolean | undefined {
+    const closestFromEach: IPointVertex[] = [];
+    const instancesLookup: { [key: string]: Points } = {};
+    let result;
+    let settings: Partial<IPointsSettings> | null = null;
+    let pointLookup: IPointVertex | null;
+
+    instances.forEach((_instance: Points) => {
+      settings = _instance.settings;
+      if (!_instance.active) return;
+      if (_instance.map !== map) return;
+
+      pointLookup = _instance.lookup(e.latlng);
+      if (pointLookup === null) return;
+      instancesLookup[pointLookup.key] = _instance;
+      closestFromEach.push(pointLookup);
+    });
+
+    if (closestFromEach.length < 1) return;
+    if (!settings) return;
+
+    const found = this.closest(e.latlng, closestFromEach, map);
+
+    if (!found) return;
+
+    const instance = instancesLookup[found.key];
+    if (!instance) return;
+    const { sensitivity } = instance;
+    const foundLatLng = found.latLng;
+    const xy = map.latLngToLayerPoint(foundLatLng);
+
+    if (
+      pixelInCircle(xy, e.layerPoint, found.chosenSize * (sensitivity ?? 1))
+    ) {
+      result = instance.contextMenu(e, found.feature || found.latLng);
       return result !== undefined ? result : true;
     }
   }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -389,6 +389,35 @@ export class Shapes extends BaseGlLayer {
     }
   }
 
+  // attempts to click the top-most Shapes instance
+  static tryContextMenu(
+    e: LeafletMouseEvent,
+    map: Map,
+    instances: Shapes[]
+  ): boolean | undefined {
+    let foundPolygon: Feature<Polygon, GeoJsonProperties> | null = null;
+    let foundShapes: Shapes | null = null;
+    instances.forEach(function (_instance: Shapes): void {
+      if (!_instance.active) return;
+      if (_instance.map !== map) return;
+      if (!_instance.polygonLookup) return;
+
+      const polygon = _instance.polygonLookup.search(
+        e.latlng.lng,
+        e.latlng.lat
+      );
+      if (polygon) {
+        foundShapes = _instance;
+        foundPolygon = polygon;
+      }
+    });
+
+    if (foundShapes && foundPolygon) {
+      const result = (foundShapes as Shapes).contextMenu(e, foundPolygon);
+      return result !== undefined ? result : undefined;
+    }
+  }
+
   hoveringFeatures: Array<
     | Feature<Polygon, GeoJsonProperties>
     | Feature<MultiPolygon, GeoJsonProperties>

--- a/src/tests/base-gl-layer.test.ts
+++ b/src/tests/base-gl-layer.test.ts
@@ -406,6 +406,18 @@ describe("BaseGlLayer", () => {
         expect(setupClick).toHaveBeenCalledWith(layer.map);
       });
     });
+    describe("when settings.contextMenu and settings.setupContextMenu are truth", () => {
+      it("calls settings.setupContextMenu with this.map", () => {
+        const contextMenu = () => {};
+        const setupContextMenu = jest.fn();
+        const layer = getGlLayer({
+          contextMenu,
+          setupContextMenu,
+        });
+        expect(layer.setup()).toBe(layer);
+        expect(setupContextMenu).toHaveBeenCalledWith(layer.map);
+      });
+    });
     describe("when settings.hover and settings.setupHover are truthy", () => {
       it("calls settings.setupHover with this.map and settings.hoverWait", () => {
         const hover: EventCallback = () => {};

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -91,6 +91,7 @@ describe("glify", () => {
         size,
         data,
         setupClick: points.settings.setupClick,
+        setupContextMenu: points.settings.setupContextMenu,
         setupHover: points.settings.setupHover,
         latitudeKey: 1,
         longitudeKey: 1,
@@ -133,6 +134,7 @@ describe("glify", () => {
         weight,
         data,
         setupClick: lines.settings.setupClick,
+        setupContextMenu: lines.settings.setupContextMenu,
         setupHover: lines.settings.setupHover,
         latitudeKey: 1,
         longitudeKey: 1,
@@ -172,6 +174,7 @@ describe("glify", () => {
         map,
         data,
         setupClick: shapes.settings.setupClick,
+        setupContextMenu: shapes.settings.setupContextMenu,
         setupHover: shapes.settings.setupHover,
         latitudeKey: 2,
         longitudeKey: 3,
@@ -269,10 +272,10 @@ describe("glify", () => {
         });
         describe("when Points.tryClick returns a value", () => {
           beforeEach(() => {
-            PointsSpy.tryCLickResult = false;
+            PointsSpy.tryClickResult = false;
           });
           afterEach(() => {
-            delete PointsSpy.tryCLickResult;
+            delete PointsSpy.tryClickResult;
           });
           it("returns early", () => {
             map.fireEvent("click", {
@@ -320,10 +323,10 @@ describe("glify", () => {
         });
         describe("when Lines.tryClick returns a value", () => {
           beforeEach(() => {
-            LinesSpy.tryCLickResult = false;
+            LinesSpy.tryClickResult = false;
           });
           afterEach(() => {
-            delete LinesSpy.tryCLickResult;
+            delete LinesSpy.tryClickResult;
           });
           it("returns early", () => {
             map.fireEvent("click", {
@@ -340,6 +343,176 @@ describe("glify", () => {
               type: "click",
             });
             expect(shapesTryClickSpy).not.toHaveBeenCalled();
+          });
+        });
+      });
+    });
+  });
+  describe.skip("setupContextMenu", () => {
+    describe("when this.contextMenuSetupMaps does not include map", () => {
+      it("pushes it to glify.maps", () => {
+        const glify = new Glify();
+        const element = document.createElement("div");
+        const map = new Map(element);
+        expect(glify.contextMenuSetupMaps.length).toBe(0);
+        glify.setupContextMenu(map);
+        expect(glify.contextMenuSetupMaps.length).toBe(1);
+      });
+    });
+    describe("when this.contextMenuSetupMaps includes map", () => {
+      it("returns early", () => {
+        const glify = new Glify();
+        const element = document.createElement("div");
+        const map = new Map(element);
+        glify.contextMenuSetupMaps.push(map);
+        expect(glify.contextMenuSetupMaps.length).toBe(1);
+        glify.setupContextMenu(map);
+        expect(glify.contextMenuSetupMaps.length).toBe(1);
+      });
+    });
+    it('calls map.on("contextMenu") correctly', () => {
+      const glify = new Glify();
+      const element = document.createElement("div");
+      const map = new Map(element);
+      jest.spyOn(map, "on");
+      glify.setupContextMenu(map);
+      expect(map.on).toHaveBeenCalled();
+    });
+    describe("when a contextMenu occurs", () => {
+      let glify: Glify;
+      let map: Map;
+      let element: HTMLElement;
+      let pointsTryContextMenuSpy: jest.SpyInstance;
+      let linesTryContextMenuSpy: jest.SpyInstance;
+      let shapesTryContextMenuSpy: jest.SpyInstance;
+      let latlng: LatLng;
+      let layerPoint: Point;
+      let containerPoint: Point;
+
+      beforeEach(() => {
+        glify = new Glify();
+        glify.Points = PointsSpy;
+        glify.Lines = LinesSpy;
+        glify.Shapes = ShapesSpy;
+        pointsTryContextMenuSpy = jest.spyOn(glify.Points, "tryContextMenu");
+        linesTryContextMenuSpy = jest.spyOn(glify.Lines, "tryContextMenu");
+        shapesTryContextMenuSpy = jest.spyOn(glify.Shapes, "tryContextMenu");
+        element = document.createElement("div");
+        map = new Map(element);
+        glify.setupContextMenu(map);
+        map.setView([10, 10], 7);
+        latlng = new LatLng(1, 1);
+        layerPoint = map.latLngToLayerPoint(latlng);
+        containerPoint = map.latLngToContainerPoint(latlng);
+      });
+      afterEach(() => {
+        pointsTryContextMenuSpy.mockRestore();
+        linesTryContextMenuSpy.mockRestore();
+        shapesTryContextMenuSpy.mockRestore();
+      });
+      describe("calling Points.tryContextMenu", () => {
+        describe("when Points.tryContextMenu returns undefined", () => {
+          it("continues on to Lines", () => {
+            //TODO: TypeError: Cannot read properties of undefined (reading 'preventDefault')
+            map.fireEvent("contextmenu", {
+              latlng,
+              layerPoint,
+              containerPoint,
+            });
+            expect(pointsTryContextMenuSpy.mock.calls[0][0]).toEqual({
+              containerPoint,
+              latlng,
+              layerPoint,
+              sourceTarget: map,
+              target: map,
+              type: "contextmenu",
+            });
+            expect(linesTryContextMenuSpy.mock.calls[0][0]).toEqual({
+              containerPoint,
+              latlng,
+              layerPoint,
+              sourceTarget: map,
+              target: map,
+              type: "contextmenu",
+            });
+          });
+        });
+        describe("when Points.tryContextMenu returns a value", () => {
+          beforeEach(() => {
+            PointsSpy.tryContextMenuResult = false;
+          });
+          afterEach(() => {
+            delete PointsSpy.tryContextMenuResult;
+          });
+          it("returns early", () => {
+            //TODO: TypeError: Cannot read properties of undefined (reading 'preventDefault')
+            map.fireEvent("contextmenu", {
+              latlng,
+              layerPoint,
+              containerPoint,
+            });
+            expect(pointsTryContextMenuSpy.mock.calls[0][0]).toEqual({
+              containerPoint,
+              latlng,
+              layerPoint,
+              sourceTarget: map,
+              target: map,
+              type: "click",
+            });
+            expect(linesTryContextMenuSpy).not.toHaveBeenCalled();
+          });
+        });
+      });
+      describe("calling Lines.tryContextMenu", () => {
+        describe("when Lines.tryContextMenu returns undefined", () => {
+          it("continues on to Shapes", () => {
+            //TODO: TypeError: Cannot read properties of undefined (reading 'preventDefault')
+            map.fireEvent("contextmenu", {
+              latlng,
+              layerPoint,
+              containerPoint,
+            });
+            expect(linesTryContextMenuSpy.mock.calls[0][0]).toEqual({
+              containerPoint,
+              latlng,
+              layerPoint,
+              sourceTarget: map,
+              target: map,
+              type: "contextmenu",
+            });
+            expect(shapesTryContextMenuSpy.mock.calls[0][0]).toEqual({
+              containerPoint,
+              latlng,
+              layerPoint,
+              sourceTarget: map,
+              target: map,
+              type: "contextmenu",
+            });
+          });
+        });
+        describe("when Lines.tryContextMenu returns a value", () => {
+          beforeEach(() => {
+            LinesSpy.tryContextMenuResult = false;
+          });
+          afterEach(() => {
+            delete LinesSpy.tryContextMenuResult;
+          });
+          it("returns early", () => {
+            //TODO: TypeError: Cannot read properties of undefined (reading 'preventDefault')
+            map.fireEvent("contextmenu", {
+              latlng,
+              layerPoint,
+              containerPoint,
+            });
+            expect(linesTryContextMenuSpy.mock.calls[0][0]).toEqual({
+              containerPoint,
+              latlng,
+              layerPoint,
+              sourceTarget: map,
+              target: map,
+              type: "contextmenu",
+            });
+            expect(shapesTryContextMenuSpy).not.toHaveBeenCalled();
           });
         });
       });
@@ -433,13 +606,23 @@ describe("glify", () => {
 });
 
 class PointsSpy extends Points {
-  static tryCLickResult: boolean | undefined;
+  static tryClickResult: boolean | undefined;
+  static tryContextMenuResult: boolean | undefined;
+
   static tryClick(
     e: LeafletMouseEvent,
     map: Map,
     instances: Points[]
   ): boolean | undefined {
-    return this.tryCLickResult;
+    return this.tryClickResult;
+  }
+
+  static tryContextMenu(
+    e: LeafletMouseEvent,
+    map: Map,
+    instances: Points[]
+  ): boolean | undefined {
+    return this.tryContextMenuResult;
   }
 
   static tryHover(
@@ -451,13 +634,22 @@ class PointsSpy extends Points {
   }
 }
 class LinesSpy extends Lines {
-  static tryCLickResult: boolean | undefined;
+  static tryClickResult: boolean | undefined;
+  static tryContextMenuResult: boolean | undefined;
   static tryClick(
     e: LeafletMouseEvent,
     map: Map,
     instances: Lines[]
   ): boolean | undefined {
-    return this.tryCLickResult;
+    return this.tryClickResult;
+  }
+
+  static tryContextMenu(
+    e: LeafletMouseEvent,
+    map: Map,
+    instances: Lines[]
+  ): boolean | undefined {
+    return this.tryContextMenuResult;
   }
 
   static tryHover(
@@ -469,13 +661,22 @@ class LinesSpy extends Lines {
   }
 }
 class ShapesSpy extends Shapes {
-  static tryCLickResult: boolean | undefined;
+  static tryClickResult: boolean | undefined;
+  static tryContextMenuResult: boolean | undefined;
   static tryClick(
     e: LeafletMouseEvent,
     map: Map,
     instances: Shapes[]
   ): boolean | undefined {
-    return this.tryCLickResult;
+    return this.tryClickResult;
+  }
+
+  static tryContextMenu(
+    e: LeafletMouseEvent,
+    map: Map,
+    instances: Shapes[]
+  ): boolean | undefined {
+    return this.tryContextMenuResult;
   }
 
   static tryHover(


### PR DESCRIPTION
Right click handling for all layers. 

Duplicates all click handling code for the `on("contextmenu")` handler, many DRY optimizations available but foregone for simplicity until [more event handlers](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b325764a0b804d8215611d234e63d8e9612e6402/types/leaflet/index.d.ts#L256C1-L323C2) are necessary and a thorough event handling structure can be set up.

Tests are incomplete due to `TypeError: Cannot read properties of undefined (reading 'preventDefault')`.

See [problem test lines](https://github.com/robertleeplummerjr/Leaflet.glify/blob/1cb451df09178f4bad2163e8494a6fc4ea05502e/src/tests/index.test.ts#L413C7-L518C10)

 Not the best with testing yet and the code works, so I would appreciate having someone review the code and add in the 2 or 3 lines I am unable to figure out to properly fire the "contextmenu" event with the ability to call `e.originalEvent.preventDefault`.

TODO: add docs to README