### PR TITLE
Don't check hover if hovering features are empty

### DIFF
--- a/src/lines.ts
+++ b/src/lines.ts
@@ -633,7 +633,7 @@ export class Lines extends BaseGlLayer<ILinesSettings> {
       if (!active
             || map !== instance.map
             || !featuresLen
-            || (!instance.hover && !instance.hoverOff)) {
+            || (!instance.hover && !instance.hoverOff)) { // if none of these method are used, no need to do all the calculations below to check whether mouse hovers some feature.
         return;
       }
 
@@ -724,6 +724,7 @@ export class Lines extends BaseGlLayer<ILinesSettings> {
         );
       }
 
+      // call `hoverOff()` only if it's really used in current instance.
       if (instance.hoverOff) {
         for (const oldHoveredFeature of oldHoveredFeatures) {
           if (!newHoveredFeatures.includes(oldHoveredFeature)) {

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -514,6 +514,7 @@ export class Lines extends BaseGlLayer<ILinesSettings> {
         weight,
         scale,
       } = instance;
+
       function checkHover(
         coordinate: Position,
         prevCoordinate: Position,
@@ -539,8 +540,13 @@ export class Lines extends BaseGlLayer<ILinesSettings> {
         }
         return false;
       }
-      if (!instance.active) return;
-      if (map !== instance.map) return;
+
+      if (!instance.active
+            || (map !== instance.map)
+            || !data.features.length) {
+        return;
+      }
+
       const oldHoveredFeatures = hoveringFeatures;
       const newHoveredFeatures: Array<Feature<LineString | MultiLineString>> =
         [];

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -5,9 +5,9 @@ import type {
   LatLng,
 } from "leaflet";
 import {
-  latLng,
-  latLngBounds,
-} from "leaflet"; // L.latLngBounds()
+  latLng, // L.latLng()
+  latLngBounds, // L.latLngBounds()
+} from "leaflet";
 
 import {
   Feature,


### PR DESCRIPTION
Otherwise, an error may occur in the inBounds() function when it checks if some point is within the bounds but the bounds are empty.

This fixes possible issue with glify.lines() layers.