### PR TITLE
fix: lng lat order wgs84 standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,40 @@ inspired by http://bl.ocks.org/Sumbera/c6fed35c377a46ff74c3 & need.
 </script>
 ```
 
+### GeoJSON & WGS84 Standard Compliance
+
+Leaflet.glify follows the **World Geodetic System (WGS84) standard** as defined by the National Geospatial-Intelligence Agency (NGA) and adopted by the GeoJSON specification.
+
+#### **Default Coordinate Order**
+
+- **Default format**: `[longitude, latitude]` (WGS84/GeoJSON standard)
+- **Why this matters**: GeoJSON specification requires coordinates in `[lng, lat]` order
+- **Reference**: [WGS84 Standard (NGA)](https://earth-info.nga.mil/php/download.php?file=coord-wgs84), [GeoJSON Specification](https://geojson.org/)
+
+
+#### **Coordinate Order Methods**
+
+```typescript
+import glify from 'leaflet.glify';
+
+// Check current coordinate order, "lngFirst" (default)
+const currentOrder = glify.getCoordinateOrder(); 
+
+// Set coordinate order
+// WGS84/GeoJSON standard [longitude, latitude]
+glify.setCoordinateOrder("lngFirst");  
+
+// Legacy format [latitude, longitude]
+glify.setCoordinateOrder("latFirst"); 
+
+// Fluent API
+// Same as setCoordinateOrder("lngFirst")
+glify.longitudeFirst();
+
+// Same as setCoordinateOrder("latFirst") 
+glify.latitudeFirst();  
+```
+
 ### Typescript
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,20 @@ const shader = {
 };
 
 export class Glify {
-  longitudeKey = 1;
-  latitudeKey = 0;
+
+  /**
+   * Coordinate order follows the World Geodetic System (WGS84) standard
+   * as defined by the National Geospatial-Intelligence Agency (NGA):
+   * https://earth-info.nga.mil/php/download.php?file=coord-wgs84
+   * 
+   * This standard is adopted by GeoJSON specification:
+   * https://geojson.org/
+   * 
+   * Coordinates are always [longitude, latitude] in WGS84/GeoJSON
+   */
+  longitudeKey = 0;
+  latitudeKey = 1;
+  
   clickSetupMaps: Map[] = [];
   contextMenuSetupMaps: Map[] = [];
   hoverSetupMaps: Map[] = [];
@@ -41,16 +53,46 @@ export class Glify {
   shapesInstances: Shapes[] = [];
   linesInstances: Lines[] = [];
 
+  /**
+   * Set coordinate order to [longitude, latitude] 
+   * WGS84/GeoJSON standard
+   * NOTE: This is the default and recommended format
+   */
   longitudeFirst(): this {
     this.longitudeKey = 0;
     this.latitudeKey = 1;
     return this;
   }
 
+
+
+
+  /**
+   * Set coordinate order to [latitude, longitude] 
+   * Legacy format: Use only for data that doesn't 
+   * follow WGS84/GeoJSON standards
+   */
   latitudeFirst(): this {
     this.latitudeKey = 0;
     this.longitudeKey = 1;
     return this;
+  }
+
+  getCoordinateOrder(): "latFirst" | "lngFirst" {
+    return this.longitudeKey === 0 ? "lngFirst" : "latFirst";
+  }
+
+  /**
+   * Set coordinate order for data parsing
+   * @param order - "lngFirst" for WGS84/GeoJSON standard [longitude, latitude]
+   *                "latFirst" for legacy format [latitude, longitude]
+   */
+  setCoordinateOrder(order: "latFirst" | "lngFirst"): this {
+    if (order === "lngFirst") {
+      return this.longitudeFirst();
+    } else {
+      return this.latitudeFirst();
+    }
   }
 
   get instances(): Array<Points | Lines | Shapes> {

--- a/src/tests/shapes_interactive.test.ts
+++ b/src/tests/shapes_interactive.test.ts
@@ -2,7 +2,17 @@ import { Feature, FeatureCollection, Polygon } from "geojson";
 import { LatLng, LeafletMouseEvent, Map, Point } from "leaflet";
 import { IShapesSettings, Shapes } from "../shapes";
 
-jest.mock("../canvas-overlay");
+jest.mock("../canvas-overlay", () => {
+  return {
+    CanvasOverlay: jest.fn().mockImplementation(() => {
+      return {
+        addTo: jest.fn().mockReturnThis(),
+        canvas: document.createElement('canvas'),
+        redraw: jest.fn(),
+      };
+    }),
+  };
+});
 
 const mockFeatureCollection: FeatureCollection<Polygon> = {
   type: "FeatureCollection",


### PR DESCRIPTION
- Fix default coordinate order to follow WGS84 standard: [longitude, latitude]
- Add comprehensive JSDoc comments with NGA and GeoJSON.org references
- Resolves open issue https://github.com/robertleeplummerjr/Leaflet.glify/issues/173