### PR TITLE
Make lon lat key order consistent across files

### DIFF
--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -231,8 +231,8 @@ export class Shapes extends BaseGlLayer {
           index = indices[i];
           if (typeof flat.vertices[0] === "number") {
             triangles.push(
-              flat.vertices[index * dim + longitudeKey],
-              flat.vertices[index * dim + latitudeKey]
+              flat.vertices[index * dim + latitudeKey],
+              flat.vertices[index * dim + longitudeKey]
             );
           } else {
             throw new Error("unhandled polygon");


### PR DESCRIPTION
https://github.com/robertleeplummerjr/Leaflet.glify/pull/189 fixed the lng lat order, but Shapes were "correct" before this fix so shapes are the one that is broken now. Now this change makes lines, shapes and points consistent to be lng lat from the GeoJSON by default. @nathanorm 